### PR TITLE
Docker slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 # voert automatisch install uit
-FROM maven:3-jdk-8-onbuild
+FROM jamesnetherton/java
+ENV MAVEN_VERSION 3.3.3
+ENV PATH /usr/share/apache-maven-${MAVEN_VERSION}/bin:${PATH}
 
+RUN apk --update add curl && \
+    curl http://apache.mirror.anlx.net/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz > /usr/share/maven.tar.gz && \
+    cd /usr/share && \
+    tar xvzf maven.tar.gz && \
+    rm -f maven.tar.gz
+#uit maven onbuild
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+ONBUILD ADD . /usr/src/app
+ONBUILD RUN mvn install
 # commando voor het uitvoeren van java jar
 CMD ["java", "-jar", "/usr/src/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apk --update add curl && \
 RUN mkdir -p /usr/share/app
 WORKDIR /usr/share/app
 COPY . /usr/share/app
-RUN mvn install
+RUN mvn install -Dmaven.test.skip=true
 # commando voor het uitvoeren van java jar
 CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apk --update add curl && \
 RUN mkdir -p /usr/share/app
 WORKDIR /usr/share/app
 COPY . /usr/share/app
-CMD mvn install -Dmaven.test.skip=true
+RUN mvn install -Dmaven.test.skip=true
 # commando voor het uitvoeren van java jar
 CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --update add curl && \
 #uit maven onbuild
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-ONBUILD ADD . /usr/src/app
-ONBUILD RUN mvn install
+COPY . /usr/src/app
+CMD ["mvn", "install"]
 # commando voor het uitvoeren van java jar
 CMD ["java", "-jar", "/usr/src/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk --update add curl && \
 RUN mkdir -p /usr/share/app
 WORKDIR /usr/share/app
 COPY . /usr/share/app
-RUN mvn install -Dmaven.test.skip=true
+RUN mvn spring-boot:run
+#RUN mvn install -Dmaven.test.skip=true
 # commando voor het uitvoeren van java jar
-CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]
+#CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --update add curl && \
 RUN mkdir -p /usr/share/app
 WORKDIR /usr/share/app
 COPY . /usr/share/app
-RUN mvn spring-boot:run
+CMD mvn spring-boot:run
 #RUN mvn install -Dmaven.test.skip=true
 # commando voor het uitvoeren van java jar
 #CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # voert automatisch install uit
-FROM jamesnetherton/java
+FROM anapsix/alpine-java
 ENV MAVEN_VERSION 3.3.3
 ENV PATH /usr/share/apache-maven-${MAVEN_VERSION}/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apk --update add curl && \
 RUN mkdir -p /usr/share/app
 WORKDIR /usr/share/app
 COPY . /usr/share/app
-RUN mvn install -Dmaven.test.skip=true
+CMD mvn install -Dmaven.test.skip=true
 # commando voor het uitvoeren van java jar
 CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apk --update add curl && \
     tar xvzf maven.tar.gz && \
     rm -f maven.tar.gz
 #uit maven onbuild
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-COPY . /usr/src/app
-CMD ["mvn", "install"]
+RUN mkdir -p /usr/share/app
+WORKDIR /usr/share/app
+COPY . /usr/share/app
+RUN mvn install
 # commando voor het uitvoeren van java jar
-CMD ["java", "-jar", "/usr/src/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]
+#CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # voert automatisch install uit
-FROM anapsix/alpine-java
+FROM anapsix/alpine-java:jdk8
 ENV MAVEN_VERSION 3.3.3
 ENV PATH /usr/share/apache-maven-${MAVEN_VERSION}/bin:${PATH}
 
@@ -14,4 +14,4 @@ WORKDIR /usr/share/app
 COPY . /usr/share/app
 RUN mvn install
 # commando voor het uitvoeren van java jar
-#CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]
+CMD ["java", "-jar", "/usr/share/app/target/Ontwikkelstraat-0.0.1-SNAPSHOT.jar"]

--- a/src/test/java/nl/atos/ontwikkelstraat/unit/controller/FormControllerTest.java
+++ b/src/test/java/nl/atos/ontwikkelstraat/unit/controller/FormControllerTest.java
@@ -61,4 +61,9 @@ public class FormControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    public void setNAW() throws Exception {
+        this.mockMvc.perform(post("/naw").accept(MediaType.APPLICATION_JSON_UTF8)).andExpect(status().isOk());
+    }
+
 }

--- a/src/test/resources/FormControllerTest.feature
+++ b/src/test/resources/FormControllerTest.feature
@@ -9,7 +9,7 @@ Feature: FormController
     And I fill in my Zipcode
     And I hit the submit button
     Then I should see my name and address data on the next page and it is also saved
-    And The browser should be closed
+    #And The browser should be closed
 
   Scenario: Fill in form on website with all data
     Given That the website is running and I navigated to it
@@ -20,13 +20,19 @@ Feature: FormController
     And I fill in my Zipcode with "1111AA"
     And I hit the submit button
     Then I should see my name and address data on the next page and it is also saved
-    And The browser should be closed
+    #And The browser should be closed
 
   Scenario Outline: test
     Given That the website is running and I navigated to it
     When I fill in my firstName with "<firstname>"
-    Then The browser should be closed
+    And I fill in my lastName with "<lastname>"
+    And I fill in my StreetName with "<streetname>"
+    And I fill in my HouseNumber with "<housenumber>"
+    And I fill in my Zipcode with "<zip>"
+    And I hit the submit button
+    Then I should see my name and address data on the next page and it is also saved
+    And The browser should be closed
     Examples:
-    |firstname|
-    |jozef    |
-    |vincent  |
+      | firstname | lastname | streetname  | housenumber | zip    |
+      | jozef     | Bilkes   | Test Straat | 29          | 1121AX |
+      | vincent   | Free     | Zonnelaan   | 221         | 9742BE |


### PR DESCRIPTION
Docker instantie kleiner gemaakt door een andere base image te gebruiken.
`FROM anapsix/alpine-java:jdk8` en daarna het zetten van MAVEN. Uiteindelijk start de applicatie vanuit de docker instantie met maven ipv vanuit een JAR. dit doe ik dan gewoon met `CMD mvn spring-boot:run`. Het is ook mogelijk om net als voorheen een JAR te maken maar dat vergroot de image tot wel een keer zo groot.